### PR TITLE
feat(deref): use in-filename to overwrite out-filename

### DIFF
--- a/src/deref.js
+++ b/src/deref.js
@@ -2,9 +2,7 @@ const fs = require("fs");
 const $RefParser = require("@apidevtools/json-schema-ref-parser");
 
 async function deref(readf, writef) {
-    if (writef === undefined) {
-        writef = readf;
-    }
+    writef = writef || readf;
     const data = fs.readFileSync(readf, 'utf8');
     const schema = await $RefParser.dereference(JSON.parse(data));
     fs.writeFileSync(writef, JSON.stringify(schema, null, 2));

--- a/src/deref.js
+++ b/src/deref.js
@@ -2,6 +2,9 @@ const fs = require("fs");
 const $RefParser = require("@apidevtools/json-schema-ref-parser");
 
 async function deref(readf, writef) {
+    if (writef === undefined) {
+        writef = readf;
+    }
     const data = fs.readFileSync(readf, 'utf8');
     const schema = await $RefParser.dereference(JSON.parse(data));
     fs.writeFileSync(writef, JSON.stringify(schema, null, 2));

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ program
 program.command("deref")
     .description("Use $RefParser to dereference a JSON schema")
     .argument("<in-filename>", "Input JSON file")
-    .argument("<out-filename>", "Output JSON file")
+    .argument("[out-filename]", "Output JSON file")
     .action(deref);
 
 program.parse();

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ program
 program.command("deref")
     .description("Use $RefParser to dereference a JSON schema")
     .argument("<in-filename>", "Input JSON file")
-    .argument("[out-filename]", "Output JSON file")
+    .argument("[out-filename]", "Output JSON file. If not specified, use in-filename.")
     .action(deref);
 
 program.parse();

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ const deref = require("./deref.js");
 const program = new Command();
 program
     .name("postprocess")
-    .description("Postprocess a OpenAPI document for ReDoc")
+    .description("Postprocess an OpenAPI document for ReDoc")
     .version("0.1.0");
 program.command("deref")
     .description("Use $RefParser to dereference a JSON schema")


### PR DESCRIPTION
close https://github.com/Oreoxmt/openapi-scripts/issues/1

I have tested it locally and it worked fine for me:

```bash
$ node src/main.js deref openapi-spec.swagger.json # without an outfile
Wrote dereferenced schema to openapi-spec.swagger.json
```