### PR TITLE
add a script to group tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Embed external Markdown file contents to the `info.description` auto-generated J
 ### Add `x-logo`
 
 [`x-logo`](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-logo) is a [vendor extension](https://swagger.io/specification/#specificationExtensions) from Redoc. It allows you to show a custom logo on the left upper corner of your redoc output.
+
+### Add tag group
+
+Add an `x-tagGroups` field to the auto-generated JSON file and group all tags under that a specified tag. This field is a Redoc vendor extension. See [Redoc documentation](https://redocly.com/docs/redoc/redoc-vendor-extensions/#x-taggroups) for more information.

--- a/src/grouptag.js
+++ b/src/grouptag.js
@@ -2,12 +2,7 @@ const fs = require("fs");
 
 function groupTag(json_file, tag_group) {
     const schema = JSON.parse(fs.readFileSync(json_file, 'utf8'));
-    const tags = [];
-
-    // iterate through schema["tags"]
-    for (let i = 0; i < schema["tags"].length; i++) {
-      tags.push(schema["tags"][i]["name"]);
-    }
+    const tags = schema["tags"].map(tag => tag["name"]);
 
     schema["x-tagGroups"] = [ {"name":tag_group, "tags": tags} ]
 

--- a/src/grouptag.js
+++ b/src/grouptag.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+
+function groupTag(json_file, tag_group) {
+    const schema = JSON.parse(fs.readFileSync(json_file, 'utf8'));
+    const tags = [];
+
+    // iterate through schema["tags"]
+    for (let i = 0; i < schema["tags"].length; i++) {
+      tags.push(schema["tags"][i]["name"]);
+    }
+
+    schema["x-tagGroups"] = [ {"name":tag_group, "tags": tags} ]
+
+    fs.writeFileSync(json_file, JSON.stringify(schema, null, 2));
+    console.log(`Group all tags in the ${tag_group} tag group.`);
+}
+
+module.exports = groupTag;

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const addLogo = require("./addlogo.js");
 const genSampleCode = require("./gencode.js");
 const devTier = require("./devTier.js");
 const replaceInteger = require("./replaceint.js");
+const groupTag = require("./grouptag.js");
 
 const program = new Command();
 program
@@ -43,4 +44,9 @@ program.command("replaceint")
     .argument("<in-filename>", "Input JSON file")
     .argument("[out-filename]", "Output JSON file. If not specified, use in-filename.")
     .action(replaceInteger);
+program.command("grouptag")
+    .description("Group all tags in a tag group")
+    .argument("<in-filename>", "Input JSON file")
+    .argument("<tag-group>", "Tag group name")
+    .action(groupTag);
 program.parse();


### PR DESCRIPTION
This command takes in a `tag group` and groups all tags in the API spec under that `tag group`.